### PR TITLE
EN-35146: follow Dockerize best practices

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # MailHog Dockerfile
 #
 
-FROM ubuntu:18.04
+FROM socrata/base-bionic
 
 # Install MailHog:
 RUN export DEBIAN_FRONTEND=noninteractive \


### PR DESCRIPTION
Switching the Docker image to Ubuntu 18.04 wasn't following our best practices done here:

https://docs.google.com/document/d/1pSYyuf32tr-eLF6HRtBIZI5fMhpHGwrkFldsGU6F9uI/edit#
